### PR TITLE
Add version of rspec matcher for RSpec v3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v2.6.0
+
+* Add rspec custom matcher `be_matching` for RSpec v3.x
+
 ### v2.5.0
 
 * Add rspec custom matcher `be_matching`

--- a/README.md
+++ b/README.md
@@ -355,42 +355,11 @@ do pattern matching and also looks like a good alternative to diff_matcher, it h
 
 Use with rspec
 ---
-To use with rspec, create a custom matcher. The following example matcher works with rspec-1.2.4 and up.
+To use with rspec, require it in `spec_helper.rb`
 
 ``` ruby
-require 'diff_matcher'
-
-# Uses the diff_matcher gem to provide advanced matching abilities, along with nice visual representation of the
-# diff between actual and expected. The functionality set is very helpful for comparing hashes.
-#
-# Usage examples:
-#  it { should be_matching(my_var) }
-#  it { should be_matching(my_var).with_options(ignore_additional: true) }
-#
-# Options: by default, color_enabled is controlled by Rspec, and quiet is set to true.
-RSpec::Matchers.define :be_matching do |expected|
-  match do |actual|
-    options = { :color_enabled => RSpec::configuration.color_enabled?, :quiet => true }.merge(@options || {})
-    @difference = DiffMatcher::Difference.new(expected, actual, options)
-    @difference.matching?
-  end
-
-  chain :with_options do |options|
-    @options = options
-  end
-
-  failure_message_for_should do |actual|
-    "diff is:\n" + @difference.to_s
-  end
-
-  failure_message_for_should_not do |actual|
-    "diff is:\n" + @difference.to_s
-  end
-
-  description do
-    "match via DiffMatcher #{expected}" + (@options.blank? ? '' : " with options: #{@options}")
-  end
-end
+require 'diff_matcher/rspec'   # for RSpec version < 3.0
+require 'diff_matcher/rspec_3' # for RSpec version >= 3.x
 ```
 
 And use it with:

--- a/lib/diff_matcher/rspec_3.rb
+++ b/lib/diff_matcher/rspec_3.rb
@@ -1,0 +1,3 @@
+require 'rspec/core'
+require 'diff_matcher'
+require 'diff_matcher/rspec_3/matchers/diff_matcher'

--- a/lib/diff_matcher/rspec_3/matchers/diff_matcher.rb
+++ b/lib/diff_matcher/rspec_3/matchers/diff_matcher.rb
@@ -1,0 +1,31 @@
+# Uses the diff_matcher gem to provide advanced matching abilities, along with nice visual representation of the
+# diff between actual and expected. The functionality set is very helpful for comparing hashes.
+#
+# Usage examples:
+#  it { should be_matching(my_var) }
+#  it { should be_matching(my_var).with_options(ignore_additional: true) }
+#
+# Options: by default, color_enabled is controlled by Rspec, and quiet is set to true.
+RSpec::Matchers.define :be_matching do |expected|
+  match do |actual|
+    options = { :color_enabled => RSpec::configuration.color_enabled?, :quiet => true }.merge(@options || {})
+    @difference = DiffMatcher::Difference.new(expected, actual, options)
+    @difference.matching?
+  end
+
+  chain :with_options do |options|
+    @options = options
+  end
+
+  failure_message do |actual|
+    "diff is:\n" + @difference.to_s
+  end
+
+  failure_message_when_negated do |actual|
+    "diff is:\n" + @difference.to_s
+  end
+
+  description do
+    "match via DiffMatcher #{expected}" + (@options.blank? ? '' : " with options: #{@options}")
+  end
+end


### PR DESCRIPTION
Was thinking of DRYing these two up with a version check to RSpec in the matcher, but didn't bother.
