### PR TITLE
Resolve Fixnum deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,13 @@
 rvm:
-#  - 1.8.6  # travis no longer supports this https://twitter.com/#!/travisci/status/114926454122364928
-  - 1.8.7
-#  - 1.9.1  # travis no longer supports this https://twitter.com/#!/travisci/status/114926454122364928
-  - 1.9.2
-  - 1.9.3
-  - rbx
-  - rbx-19mode
-  - rbx-2
-  - jruby
-  - ree
   - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0
+  - 2.4.0
+  - 2.5.0
+  - 2.6.0
+  - 2.7.0
+  - 3.0.0
   - ruby-head
 
 before_install:
@@ -20,7 +15,3 @@ before_install:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - rvm: rbx
-    - rvm: rbx-19mode
-    - rvm: rbx-2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### v2.9.0
+
+* Resolve Fixnum deprecation warnings with Ruby 2.4+
+
+### v2.8.1
+
+* Create shared CLI module
+
 ### v2.8.0
 
 * Add new diff-* executables for matching JSON & CSV files on the command line

--- a/lib/diff_matcher/difference.rb
+++ b/lib/diff_matcher/difference.rb
@@ -53,7 +53,7 @@ module DiffMatcher
       opts = expected_opts(e)
       size = opts[:size]
       case size
-      when Fixnum
+      when 0.class
         min = size
         max = size
       when Range

--- a/lib/diff_matcher/version.rb
+++ b/lib/diff_matcher/version.rb
@@ -1,3 +1,3 @@
 module DiffMatcher
-  VERSION = "2.8.1"
+  VERSION = "2.9.0"
 end

--- a/spec/diff_matcher/difference_spec.rb
+++ b/spec/diff_matcher/difference_spec.rb
@@ -42,8 +42,8 @@ end
 
 describe DiffMatcher::Matcher do
   expected, expected2, same, different, difference =
-    {:nombre => String   , :edad   => Integer },
-    {:name   => String   , :age    => Integer },
+    {:nombre => String   , :edad   => 0.class },
+    {:name   => String   , :age    => 0.class },
     {:name   => "Peter"  , :age    => 21      },
     {:name   => 21       , :age    => 21      },
     "{\n  :name=>\e[31m- \e[1mString\e[0m\e[33m+ \e[1m21\e[0m,\n  :age=>\e[34m: \e[1m21\e[0m\n}\n"
@@ -126,7 +126,7 @@ describe "DiffMatcher::Matcher[expected].diff(actual, opts)" do
   subject { DiffMatcher::Matcher[expected].diff(actual, opts) }
 
   describe "when expected is an instance," do
-    context "of Fixnum," do
+    context "of Integer," do
       expected, same, different =
         1,
         1,
@@ -140,7 +140,7 @@ describe "DiffMatcher::Matcher[expected].diff(actual, opts)" do
   describe "when expected is an instance," do
     context "of Hash, with optional keys" do
       expected, same, different =
-        {:a=>1, :b=>Fixnum},
+        {:a=>1, :b=>0.class},
         {:a=>1},
         {:a=>2}
 
@@ -156,7 +156,7 @@ describe "DiffMatcher::difference(expected, actual, opts)" do
   subject { DiffMatcher::difference(expected, actual, opts) }
 
   describe "when expected is an instance," do
-    context "of Fixnum," do
+    context "of Integer," do
       expected, same, different =
         1,
         1,
@@ -534,7 +534,7 @@ describe "DiffMatcher::difference(expected, actual, opts)" do
 
       context "or-ed with another DiffMatcher::Matcher," do
         expected, same, different =
-          DiffMatcher::Matcher[Fixnum] | DiffMatcher::Matcher[String],
+          DiffMatcher::Matcher[0.class] | DiffMatcher::Matcher[String],
           "a",
           1.0
 
@@ -635,7 +635,7 @@ describe "DiffMatcher::difference(expected, actual, opts)" do
 
     context "a DiffMatcher::AllMatcher using an or-ed DiffMatcher::Matcher," do
       expected, same, different =
-        DiffMatcher::AllMatcher[ DiffMatcher::Matcher[Fixnum, Float] ],
+        DiffMatcher::AllMatcher[ DiffMatcher::Matcher[0.class, Float] ],
         [1, 2.0, 3],
         [1, "2", 3]
 
@@ -653,8 +653,8 @@ describe "DiffMatcher::difference(expected, actual, opts)" do
         expected, same, different =
           DiffMatcher::AllMatcher[
             DiffMatcher::Matcher[
-              {:nombre=>String, :edad=>Fixnum},
-              {:name=>String, :age=>Fixnum}
+              {:nombre=>String, :edad=>0.class},
+              {:name=>String, :age=>0.class}
             ]
           ],
           [
@@ -674,7 +674,7 @@ describe "DiffMatcher::difference(expected, actual, opts)" do
             | {:name=>"Alice", :age=>10},
             {
               :name=>: "Bob",
-              :age=>- Fixnum+ nil
+              :age=>- 0.class+ nil
             },
             | {:nombre=>"Con", :edad=>30}
           ]
@@ -698,7 +698,7 @@ describe "DiffMatcher::difference(expected, actual, opts)" do
       end
     end
     expected, same, different =
-      [ 1,  2, /\d/, Fixnum, 4..6 , lambda { |x| x % 6 == 0 }, matchable.new(7)],
+      [ 1,  2, /\d/, 0.class, 4..6 , lambda { |x| x % 6 == 0 }, matchable.new(7)],
       [ 1,  2, "3" , 4     , 5    , 6                        , 7               ],
       [ 0,  2, "3" , 4     , 5    , 6                        , 7               ]
 


### PR DESCRIPTION
Hi :)

I've cleaned up Fixnum deprecation warnings with modern rubies, and removed non supported/working ruby versions from .travis.
In theory there's no breaking changes, but bumped to 2.9 just in case.